### PR TITLE
#AA-228: Range Slider position calculations

### DIFF
--- a/src/components/UiInputRange/UiInputRange.tsx
+++ b/src/components/UiInputRange/UiInputRange.tsx
@@ -27,23 +27,21 @@ export const UiInputRange: React.FC<TUiInputRangeProps> = ({
 	const updatePositions = React.useCallback(() => {
 		if (!track.current || !thumb.current) return;
 
-		requestAnimationFrame(() => {
-			const numValue = parseFloat(String(value));
-			const numMin = parseFloat(String(min));
-			const numMax = parseFloat(String(max));
+		const numValue = parseFloat(String(value));
+		const numMin = parseFloat(String(min));
+		const numMax = parseFloat(String(max));
 
-			const thumbWidth = thumb.current?.getBoundingClientRect().width ?? 0;
-			const trackWidth = track.current?.getBoundingClientRect().width ?? 0;
+		const thumbWidth = thumb.current?.getBoundingClientRect().width ?? 0;
+		const trackWidth = track.current?.getBoundingClientRect().width ?? 0;
 
-			if (trackWidth === 0) return;
+		if (trackWidth === 0) return;
 
-			const percentage = ((numValue - numMin) / (numMax - numMin)) * 100;
-			const thumbWidthPercentage = (thumbWidth / trackWidth) * 100;
+		const percentage = ((numValue - numMin) / (numMax - numMin)) * 100;
+		const thumbWidthPercentage = (thumbWidth / trackWidth) * 100;
 
-			const adjustedPercentage = Math.max(0, Math.min(100, percentage * (1 - thumbWidthPercentage / 100)));
+		const adjustedPercentage = Math.max(0, Math.min(100, percentage * (1 - thumbWidthPercentage / 100)));
 
-			setPosition(adjustedPercentage);
-		});
+		setPosition(adjustedPercentage);
 	}, [min, max, value]);
 
 	React.useEffect(() => {

--- a/src/components/UiInputRange/UiInputRange.tsx
+++ b/src/components/UiInputRange/UiInputRange.tsx
@@ -94,7 +94,7 @@ export const UiInputRange: React.FC<TUiInputRangeProps> = ({
 			<div className="pointer-events-none absolute left-0 top-1/2 h-xxs w-full -translate-y-1/2 rounded-sm bg-secondary-alt" />
 
 			<div
-				className="pointer-events-none absolute left-0 top-1/2 h-xxs -translate-y-1/2 rounded-sm bg-primary"
+				className="pointer-events-none absolute left-0 top-1/2 h-xxs -translate-y-1/2 rounded-sm bg-primary-600"
 				style={ {
 					width: `${position}%`,
 				} }
@@ -110,14 +110,14 @@ export const UiInputRange: React.FC<TUiInputRangeProps> = ({
 					"-translate-y-1/2",
 					"rounded-full",
 					"bg-white",
-					"border-primary",
+					"border-primary-600",
 				) }
 				ref={ thumb }
 				style={ {
 					left: `${position}%`,
 				} }
 			>
-				<div className="absolute left-1/2 top-1/2 size-xxs -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary" />
+				<div className="absolute left-1/2 top-1/2 size-xxs -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-600" />
 			</div>
 		</div>
 	);

--- a/src/components/UiInputRange/UiInputRange.tsx
+++ b/src/components/UiInputRange/UiInputRange.tsx
@@ -22,27 +22,45 @@ export const UiInputRange: React.FC<TUiInputRangeProps> = ({
 }) => {
 	const track = React.useRef<HTMLInputElement>(null);
 	const thumb = React.useRef<HTMLDivElement>(null);
+	const [position, setPosition] = React.useState(0);
 
-	const [thumbPosition, setThumbPosition] = React.useState(0);
-	const [trackWidth, setTrackWidth] = React.useState(0);
-
-	React.useEffect(() => {
+	const updatePositions = React.useCallback(() => {
 		if (!track.current || !thumb.current) return;
 
-		const numValue = parseFloat(String(value));
-		const numMin = parseFloat(String(min));
-		const numMax = parseFloat(String(max));
+		requestAnimationFrame(() => {
+			const numValue = parseFloat(String(value));
+			const numMin = parseFloat(String(min));
+			const numMax = parseFloat(String(max));
 
-		const percentage = ((numValue - numMin) / (numMax - numMin)) * 100;
+			const thumbWidth = thumb.current?.getBoundingClientRect().width ?? 0;
+			const trackWidth = track.current?.getBoundingClientRect().width ?? 0;
 
-		const thumbWidth = thumb.current.getBoundingClientRect().width;
-		const trackWidth = track.current.clientWidth;
-		const thumbWidthPercentage = (thumbWidth / trackWidth) * 100;
-		const adjustedPercentage = percentage * (1 - thumbWidthPercentage / 100);
+			if (trackWidth === 0) return;
 
-		setThumbPosition(Math.max(0, Math.min(100, adjustedPercentage)));
-		setTrackWidth(Math.max(0, Math.min(100, adjustedPercentage + thumbWidthPercentage)));
+			const percentage = ((numValue - numMin) / (numMax - numMin)) * 100;
+			const thumbWidthPercentage = (thumbWidth / trackWidth) * 100;
+
+			const adjustedPercentage = Math.max(0, Math.min(100, percentage * (1 - thumbWidthPercentage / 100)));
+
+			setPosition(adjustedPercentage);
+		});
 	}, [min, max, value]);
+
+	React.useEffect(() => {
+		updatePositions();
+
+		const resizeObserver = new ResizeObserver(() => {
+			updatePositions();
+		});
+
+		if (track.current) {
+			resizeObserver.observe(track.current);
+		}
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	}, [updatePositions]);
 
 	const handleOnChange = (newValue: number) => {
 		if (newValue === value) return;
@@ -80,7 +98,7 @@ export const UiInputRange: React.FC<TUiInputRangeProps> = ({
 			<div
 				className="pointer-events-none absolute left-0 top-1/2 h-xxs -translate-y-1/2 rounded-sm bg-primary"
 				style={ {
-					width: `${trackWidth}%`,
+					width: `${position}%`,
 				} }
 			/>
 
@@ -98,7 +116,7 @@ export const UiInputRange: React.FC<TUiInputRangeProps> = ({
 				) }
 				ref={ thumb }
 				style={ {
-					left: `${thumbPosition}%`,
+					left: `${position}%`,
 				} }
 			>
 				<div className="absolute left-1/2 top-1/2 size-xxs -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary" />

--- a/src/components/UiPlainRadio/UiPlainRadio.tsx
+++ b/src/components/UiPlainRadio/UiPlainRadio.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import cx from "classnames";
 import { UiRadio } from "../UiRadio";
 
-export type  TUiPlainRadio = {
+export type TUiPlainRadio = {
 	children?: React.ReactNode
 	disabled?: boolean;
 	subHeader?: string;
@@ -12,7 +12,7 @@ export type  TUiPlainRadio = {
 	checked?: boolean
 	onChange: (value: string) => void;
 
-}& Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "checked" | "value" | "name">;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "checked" | "value" | "name">;
 
 export const UiPlainRadio: React.FC<TUiPlainRadio> = ({
 	children,
@@ -46,7 +46,7 @@ export const UiPlainRadio: React.FC<TUiPlainRadio> = ({
 			type="radio"
 			value={ value }
 			checked={ checked }
-			onChange={ ()=> onChange(value) }
+			onChange={ () => onChange(value) }
 			/>
 
 			<div className={ cx(
@@ -80,11 +80,12 @@ export const UiPlainRadio: React.FC<TUiPlainRadio> = ({
 			>
 
 				<UiRadio
+					id={ `ui-plain-radio-${name}-${value}` }
 					className="pointer-events-none"
 					disabled={ disabled }
 					value={ value }
 					name={ name }
-					onChange={ ()=> onChange(value) }
+					onChange={ () => onChange(value) }
 					checked={ checked }
 					tabIndex={ -1 }
 				/>

--- a/src/components/UiRadio/UiRadio.tsx
+++ b/src/components/UiRadio/UiRadio.tsx
@@ -24,6 +24,7 @@ const justificationClasses = {
 };
 
 export const UiRadio: React.FC<TUiRadioProps> = ({
+	id,
 	name,
 	value,
 	invertOrder = false,
@@ -56,7 +57,7 @@ export const UiRadio: React.FC<TUiRadioProps> = ({
 				}
 			) }>
 			<input
-				id={ value }
+				id={ id || `${name}-${value}` }
 				name={ name.toString() }
 				type="radio"
 				value={ value }

--- a/src/components/UiToggle/UiToggle.stories.tsx
+++ b/src/components/UiToggle/UiToggle.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { UiToggle } from "./UiToggle";
+import { EJustify } from "../../_types/align";
 
 const meta = {
 	title: "Components/UiToggle",
@@ -17,6 +18,13 @@ const meta = {
 				type: "boolean",
 			},
 			description: "Toggle Disabled",
+		},
+		justify: {
+			control: {
+				type: "select"
+			},
+			options: Object.values(EJustify),
+			description: "The Element justify",
 		},
 		invertOrder: {
 			control: {

--- a/src/components/UiToggle/UiToggle.tsx
+++ b/src/components/UiToggle/UiToggle.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from "react";
 import cx from "classnames";
 import styles from "./UiToggle.module.css";
+import { EJustify } from "../../_types/align";
 
 type TUiToggleProps = {
 	children?: React.ReactNode
 	disabled?: boolean
 	invertOrder?: boolean
+	justify?: EJustify;
 	defaultChecked?: boolean
 	checked?: boolean
 	value?: boolean
@@ -16,6 +18,7 @@ export const UiToggle: React.FC<TUiToggleProps> = ({
 	children,
 	disabled = false,
 	invertOrder = false,
+	justify = EJustify.START,
 	checked,
 	value,
 	className,
@@ -42,110 +45,115 @@ export const UiToggle: React.FC<TUiToggleProps> = ({
 		}
 	}, [checked]);
 
+	const justificationClasses = {
+		[EJustify.START]: "justify-start",
+		[EJustify.END]: "justify-end",
+		[EJustify.CENTER]: "justify-center",
+		[EJustify.BETWEEN]: "justify-between",
+		[EJustify.AROUND]: "justify-around",
+		[EJustify.EVENLY]: "justify-evenly"
+	};
+
 	return (
-		<div className={ cx(
+		<label className={ cx(
 			"ui-toggle",
+			"flex",
+			"cursor-pointer",
+			"gap-sm",
+			"rounded-full",
+			"items-center",
+			"w-full",
+			"leading-normal",
+			"text-md",
+			{
+				"flex-row-reverse": invertOrder,
+				"pointer-events-none opacity-50": disabled
+			},
+			justificationClasses[justify],
 			className
-		) }
-		>
-
-			<label className={ cx(
-				"flex",
-				"cursor-pointer",
-				"gap-sm",
-				"rounded-full",
-				"mt-sm",
-				"items-center",
-				"w-full",
-				"leading-normal",
-				"text-md",
-				{
-					"flex-row-reverse": invertOrder,
-					"pointer-events-none opacity-50": disabled
-				}
-
+		) }>
+			<span className={ cx(
+				"relative",
+				"block",
+				"h-md"
 			) }>
+
+				<input className={ cx(
+					"absolute",
+					"size-0",
+					"appearance-none",
+					"border-0"
+				) }
+				type="checkbox"
+				checked={ isChecked }
+				onChange={ handleChange }
+				disabled={ disabled }
+				value={ value }
+				{ ...rest }
+				>
+				</input>
+
 				<span className={ cx(
-					"relative",
 					"block",
-					"h-md"
+					"h-md",
+					"w-xl",
+					"rounded-full",
+					{
+						"bg-primary-600": isChecked && !disabled,
+						"bg-secondary-alt-300": !isChecked && disabled,
+						"bg-secondary-alt-600": !isChecked && !disabled,
+						"bg-primary-300": isChecked && disabled
+
+					}
+				) }/>
+
+				<span className={ cx(
+					"absolute",
+					"top-[50%]",
+					"block",
+					"rounded-full",
+					"bg-white",
+					styles.UiToggle__dot,
+					{
+						"hover:shadow-border-secondary": !isChecked && !disabled,
+						"hover:shadow-border-primary": isChecked && !disabled,
+						[styles.UiToggle__dot_checked]: isChecked
+					},
+
 				) }>
 
-					<input className={ cx(
-						"absolute",
-						"size-0",
-						"appearance-none",
-						"border-0"
-					) }
-					type="checkbox"
-					checked={ isChecked }
-					onChange={ handleChange }
-					disabled={ disabled }
-					value={ value }
-					{ ...rest }
+					<svg
+						className={ cx(
+							styles.UiToggle__icon,
+							"absolute",
+							disabled
+								? "text-primary-300"
+								: "text-primary-600",
+							{
+								[styles.UiToggle__icon_checked]: isChecked ,
+							}
+
+						) }
+						width="16"
+						height="16"
+						viewBox="0 0 16 16"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
 					>
-					</input>
+						<path
+							d="M1 4.40106L6.60071 10.1135L15.1694 1.71245"
+							stroke="currentColor"
+							stroke-width="1.6"
+							stroke-linecap="round"
+						/>
+					</svg>
 
-					<span className={ cx(
-						"block",
-						"h-md",
-						"w-xl",
-						"rounded-full",
-						{
-							"bg-primary-600": isChecked && !disabled,
-							"bg-secondary-alt-300": !isChecked && disabled,
-							"bg-secondary-alt-600": !isChecked && !disabled,
-							"bg-primary-300": isChecked && disabled
-
-						}
-					) }/>
-
-					<span className={ cx(
-						"absolute",
-						"top-[50%]",
-						"block",
-						"rounded-full",
-						"bg-white",
-						styles.UiToggle__dot,
-						{
-							"hover:shadow-border-secondary": !isChecked && !disabled,
-							"hover:shadow-border-primary": isChecked && !disabled,
-							[styles.UiToggle__dot_checked]: isChecked
-						},
-
-					) }>
-
-						<svg
-							className={ cx(
-								styles.UiToggle__icon,
-								"absolute",
-								disabled ? "text-primary-300" : "text-primary-600",
-								{
-									[styles.UiToggle__icon_checked]: isChecked ,
-								}
-
-							) }
-							width="16"
-							height="16"
-							viewBox="0 0 16 16"
-							fill="none"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							<path
-								d="M1 4.40106L6.60071 10.1135L15.1694 1.71245"
-								stroke="currentColor"
-								stroke-width="1.6"
-								stroke-linecap="round"
-							/>
-						</svg>
-
-					</span>
 				</span>
+			</span>
 
-				{ children }
+			{ children }
 
-			</label>
+		</label>
 
-		</div>
 	);
 };


### PR DESCRIPTION
Updated the thumb and track position logic for range inputs - issue arose when element resized and the calculations did not rerun
Also fixed issue with UiRadio/UiPlainRadio where the `id` property was duplicated across html input elements