### PR TITLE
#AA-321 update(UISkeleton): result card mobile responsive

### DIFF
--- a/src/components/UiSkeleton/UiSkeleton.tsx
+++ b/src/components/UiSkeleton/UiSkeleton.tsx
@@ -82,11 +82,10 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 
 							<div className={ cx("flex", "flex-wrap", "gap-xs", "mb-xxs") }>
 								{ ["w-2/5", "w-1/4"].map((widthClass, index) => {
-									const bgClass = "bg-secondary-alt-300";
 									return (
 										<div
 											key={ index }
-											className={ cx(widthClass, "h-md", bgClass, "rounded-sm") }
+											className={ cx(widthClass, "h-md", "bg-secondary-alt-300", "rounded-sm") }
 										/>
 									);
 								}) }

--- a/src/components/UiSkeleton/UiSkeleton.tsx
+++ b/src/components/UiSkeleton/UiSkeleton.tsx
@@ -119,9 +119,6 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 								"p-xs md:border-b-0 border-b"
 							) }>
 								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
-									const heightClass = index === 1
-										? "h-md"
-										: "h-[20px]";
 									return (
 										<div
 											key={ index }
@@ -130,7 +127,9 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 												"mb-xxxs",
 												"rounded-sm",
 												widthClass,
-												heightClass
+												index === 1
+													? "h-md"
+													: "h-[20px]"
 											) }
 										/>
 									);

--- a/src/components/UiSkeleton/UiSkeleton.tsx
+++ b/src/components/UiSkeleton/UiSkeleton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import cx from "classnames";
 import { ESkeletonKind } from "./_types";
 
-type UiSkeletonProps ={
+type UiSkeletonProps = {
 	kind: ESkeletonKind
 	className?: string
 }
@@ -23,7 +23,7 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						"animate-pulse",
 						"border-2",
 						"border-secondary-alt-300",
-						"grid grid-cols-[120px_1fr_180px]",
+						"md:grid md:grid-cols-[120px_1fr_180px]",
 						"rounded-2xl",
 					) }
 				>
@@ -31,13 +31,11 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						className={ cx(
 							"ui-skeleton-card__content",
 							"bg-secondary-alt-300",
-							"gap-xs",
-							"items-center",
-							"justify-center",
-							"p-md",
-							"rounded-bl-xl",
-							"rounded-tl-xl"
-
+							"flex gap-xs items-center justify-center",
+							"px-sm py-xxs",
+							"md:border-r md:border-b-0 border-t-0 border-b border-secondary-alt-400",
+							"md:rounded-tl-xl md:rounded-bl-xl md:rounded-tr-0",
+							"rounded-tl-xl rounded-tr-xl md:rounded-br-0"
 						) }
 					>
 						<div className={ cx("grid", "grow", "gap-xxs", "justify-items-center") }>
@@ -45,10 +43,10 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 								className={ cx(
 									"ui-skeleton-card__content",
 									"bg-secondary-alt-400",
-									"h-xl",
+									"h-xxxl",
 									"mb-sm",
 									"rounded-sm",
-									"w-xxxxl"
+									"w-xxxl"
 								) }
 							/>
 							<div
@@ -57,22 +55,21 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 									"bg-secondary-alt-400",
 									"h-xxxxl",
 									"rounded-full",
-									"w-xxxxl"
+									"w-xxxxl",
+									"hidden md:block"
 								) }
 							/>
 						</div>
-
 					</div>
+
 					<div
 						className={ cx(
 							"ui-skeleton-main__content",
 							"bg-white",
-						) }>
-						<div className={ cx(
-							"grid",
-							"p-sm"
-
-						) }>
+							"md:border-b-0"
+						) }
+					>
+						<div className={ cx("grid", "gap-xxs", "p-sm") }>
 							<div
 								className={ cx(
 									"bg-secondary-alt-400",
@@ -83,14 +80,9 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 								) }
 							/>
 
-							<div className={ cx(
-								"flex",
-								"gap-sm",
-								"mb-xxs"
-							) }>
+							<div className={ cx("flex", "flex-wrap", "gap-xs", "mb-xxs") }>
 								{ ["w-2/5", "w-1/4"].map((widthClass, index) => {
-									const bgClass = index === 0 ? "bg-secondary-alt-300" : "bg-secondary-alt-300";
-
+									const bgClass = "bg-secondary-alt-300";
 									return (
 										<div
 											key={ index }
@@ -100,15 +92,12 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 								}) }
 							</div>
 
-							<div className={ cx(
-								"flex",
-								"justify-between",
-
-							) }>
+							<div className={ cx("flex", "justify-between") }>
 								{ ["w-1/3", "w-1/4"].map((widthClass, index) => {
 									const heightClass = "h-[20px]";
-									const bgClass = index === 0 ? "bg-secondary-alt-400" : "bg-secondary-alt-300";
-
+									const bgClass = index === 0
+										? "bg-secondary-alt-400"
+										: "bg-secondary-alt-300";
 									return (
 										<div
 											key={ index }
@@ -119,88 +108,96 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 							</div>
 						</div>
 
-						<div className={ cx(
-							"grid",
-							"grid-cols-4",
+						<div className={ cx("border-t border-secondary-alt-400", "md:grid md:grid-cols-2") }>
+							<div className={ cx(
+								"flex flex-col justify-between md:justify-center md:items-center md:flex-col",
+								"md:border-r border-secondary-alt-400",
+								"p-xs md:border-b-0 border-b"
+							) }>
+								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
+									const heightClass = index === 1
+										? "h-md"
+										: "h-[20px]";
+									return (
+										<div
+											key={ index }
+											className={ cx(
+												"bg-secondary-alt-300",
+												"mb-xxxs",
+												"rounded-sm",
+												widthClass,
+												heightClass
+											) }
+										/>
+									);
+								}) }
+							</div>
 
-						) } >
-							{ Array.from({
-								length: 4
-							}).map((_, index)=> (
-								<div key={ index } className={ cx(
-									"border",
-									"border-secondary-alt-300",
-									"px-xs",
-									"py-md"
-
-								) } >
-									<div className={ cx(
-										"place-items-center"
-
-									) }>
-										{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
-
-											const heightClass = index === 1 ? "h-md" : "h-[20px]";
-
-											return (
-												<div
-													key={ index }
-													className={ cx(
-														"bg-secondary-alt-300",
-														"mb-xxxs",
-														"rounded-sm",
-														widthClass,
-														heightClass
-													) }
-												/>
-											);
-										}) }
-									</div>
-								</div>
-							)) }
-
+							<div className={ cx(
+								"flex flex-col justify-between md:justify-center md:items-center md:flex-col",
+								"p-xs"
+							) }>
+								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
+									const heightClass = index === 1
+										? "h-md"
+										: "h-[20px]";
+									return (
+										<div
+											key={ index }
+											className={ cx(
+												"bg-secondary-alt-300",
+												"mb-xxxs",
+												"rounded-sm",
+												widthClass,
+												heightClass
+											) }
+										/>
+									);
+								}) }
+							</div>
 						</div>
-
 					</div>
+
 					<div
 						className={ cx(
 							"ui-skeleton-cta-cell",
 							"bg-secondary-alt-200",
-							"flex-col",
-							"flex",
-							"items-center",
-							"px-sm",
-							"py-md",
-							"rounded-br-xl",
-							"rounded-tr-xl"
+							"flex flex-row md:flex-col md:grid md:place-content-center md:items-center md:gap-sm",
+							"border-t md:border-t-0 border-l-0 md:border-l border-secondary-alt-400",
+							"p-sm justify-between items-center",
+							"md:rounded-tr-xl md:rounded-br-xl md:rounded-bl-0",
+							"rounded-bl-xl rounded-br-xl md:rounded-tl-0"
+						) }
+					>
+						<div className={ cx("flex flex-col md:items-center") }>
+							{ ["w-3/4", "w-1/2"].map((widthClass, index) => {
+								const heightClass = index === 0
+									? "h-lg"
+									: "h-[20px]";
+								return (
+									<div
+										key={ index }
+										className={ cx(
+											"bg-secondary-alt-400",
+											"mb-xxxs",
+											"rounded-sm",
+											widthClass,
+											heightClass
+										) }
+									/>
+								);
+							}) }
+						</div>
 
-						) }>
-						{ ["w-3/4", "w-1/2", "w-3/4", "w-4/5"].map((widthClass, index) => {
-
-							const heightClass = index === 1 ? "h-lg" : "h-[20px]";
-							const lastDivClass = index === 3 ? "h-xxl bg-secondary-alt-500 mt-md" : heightClass;
-
-							return (
-								<div
-									key={ index }
-									className={ cx(
-										"ui-skeleton-cta-cell__content",
-										"bg-secondary-alt-400",
-										"flex-col",
-										"flex",
-										"h-[20px]",
-										"mb-xxxs",
-										"rounded-sm",
-										widthClass,
-										heightClass,
-										lastDivClass
-									) }
-								/>
-							);
-						}) }
-
+						<div
+							className={ cx(
+								"bg-secondary-alt-500",
+								"h-xxl",
+								"rounded-sm",
+								"w-3/4 md:w-4/5"
+							) }
+						/>
 					</div>
-
 				</div>
 
 			) }
@@ -289,12 +286,16 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 								"border-secondary-alt-300",
 								"py-xxs",
 								"place-items-center",
-								index === 2 ? "border-r-0" : ""
+								index === 2
+									? "border-r-0"
+									: ""
 
 							) } >
 
 								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
-									const bgClass = index === 0 ? "bg-secondary-alt-300" : "bg-secondary-alt-400";
+									const bgClass = index === 0
+										? "bg-secondary-alt-300"
+										: "bg-secondary-alt-400";
 
 									return (
 										<div
@@ -323,7 +324,9 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						"my-xxs"
 					) }>
 						{ ["w-2/6", "w-2/6"].map((widthClass, index) => {
-							const bgClass = index === 0 ? "bg-secondary-alt-300" : "bg-secondary-alt-300";
+							const bgClass = index === 0
+								? "bg-secondary-alt-300"
+								: "bg-secondary-alt-300";
 
 							return (
 								<div
@@ -348,8 +351,14 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						) }>
 
 							{ ["w-3/5", "w-2/5", "w-3/6","w-3/5"].map((widthClass, index) => {
-								const bgClass = index === 3 ? "bg-secondary-alt-400" : "bg-secondary-alt-300";
-								const heightClass = index === 2 ? "h-md" : index === 3 ? "h-sm" : "h-[20px]";
+								const bgClass = index === 3
+									? "bg-secondary-alt-400"
+									: "bg-secondary-alt-300";
+								const heightClass = index === 2
+									? "h-md"
+									: index === 3
+										? "h-sm"
+										: "h-[20px]";
 								return (
 
 									<div
@@ -375,10 +384,20 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						) }>
 
 							{ ["w-3/6", "w-2/5", "w-3/5"].map((widthClass, index)=> {
-								const bgClass = index === 1 ? "bg-secondary-alt-300" : "bg-secondary-alt-400";
-								const roundClass = index === 2 ? "rounded-full" : "rounded-sm";
-								const heightClass = index === 1 ? "h-[20px]" : "h-md";
-								const marginsClass = index === 0  ? "mt-xxs" : index === 2 ? "mt-xxs" : "mt-0";
+								const bgClass = index === 1
+									? "bg-secondary-alt-300"
+									: "bg-secondary-alt-400";
+								const roundClass = index === 2
+									? "rounded-full"
+									: "rounded-sm";
+								const heightClass = index === 1
+									? "h-[20px]"
+									: "h-md";
+								const marginsClass = index === 0
+									? "mt-xxs"
+									: index === 2
+										? "mt-xxs"
+										: "mt-0";
 								return (
 
 									<div

--- a/src/components/UiSkeleton/UiSkeleton.tsx
+++ b/src/components/UiSkeleton/UiSkeleton.tsx
@@ -94,7 +94,7 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 
 						<div className={ cx("border-t border-secondary-alt-300", "md:grid md:grid-cols-2") }>
 							<div className={ cx(
-								"flex flex-col justify-between md:justify-center md:items-center md:flex-col",
+								"hidden md:flex flex-col justify-between md:justify-center md:items-center md:flex-col",
 								"md:border-r border-secondary-alt-300",
 								"p-xs md:border-b-0 border-b"
 							) }>
@@ -122,7 +122,6 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						) }
 					>
 						<div className={ cx("flex flex-col md:items-center w-full") }>
-							<div className={ cx("bg-secondary-alt-300", "mb-xxxs", "rounded-sm", "h-lg", "w-[120px]") } />
 							<div className={ cx("bg-secondary-alt-300", "mb-xxxs", "rounded-sm", "h-lg", "w-[120px]") } />
 						</div>
 

--- a/src/components/UiSkeleton/UiSkeleton.tsx
+++ b/src/components/UiSkeleton/UiSkeleton.tsx
@@ -33,9 +33,9 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 							"bg-secondary-alt-300",
 							"flex gap-xs items-center justify-center",
 							"px-sm py-xxs",
-							"md:border-r md:border-b-0 border-t-0 border-b border-secondary-alt-400",
-							"md:rounded-tl-xl md:rounded-bl-xl md:rounded-tr-0",
-							"rounded-tl-xl rounded-tr-xl md:rounded-br-0"
+							"md:border-b-0 border-t-0 border-b border-secondary-alt-300",
+							"md:rounded-tl-xl md:rounded-bl-xl",
+							"rounded-tl-xl md:rounded-br-0"
 						) }
 					>
 						<div className={ cx("grid", "grow", "gap-xxs", "justify-items-center") }>
@@ -44,7 +44,7 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 									"ui-skeleton-card__content",
 									"bg-secondary-alt-400",
 									"h-xxxl",
-									"mb-sm",
+									"md:mb-sm",
 									"rounded-sm",
 									"w-xxxl"
 								) }
@@ -111,10 +111,10 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 							</div>
 						</div>
 
-						<div className={ cx("border-t border-secondary-alt-400", "md:grid md:grid-cols-2") }>
+						<div className={ cx("border-t border-secondary-alt-300", "md:grid md:grid-cols-2") }>
 							<div className={ cx(
 								"flex flex-col justify-between md:justify-center md:items-center md:flex-col",
-								"md:border-r border-secondary-alt-400",
+								"md:border-r border-secondary-alt-300",
 								"p-xs md:border-b-0 border-b"
 							) }>
 								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
@@ -140,9 +140,6 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 								"p-xs"
 							) }>
 								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
-									const heightClass = index === 1
-										? "h-md"
-										: "h-[20px]";
 									return (
 										<div
 											key={ index }
@@ -151,7 +148,9 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 												"mb-xxxs",
 												"rounded-sm",
 												widthClass,
-												heightClass
+												index === 1
+													? "h-md"
+													: "h-[20px]"
 											) }
 										/>
 									);
@@ -165,17 +164,15 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 							"ui-skeleton-cta-cell",
 							"bg-secondary-alt-200",
 							"flex flex-row md:flex-col md:grid md:place-content-center md:items-center md:gap-sm",
-							"border-t md:border-t-0 border-l-0 md:border-l border-secondary-alt-400",
+							"border-t md:border-t-0 border-l-0 border-secondary-alt-300",
 							"p-sm justify-between items-center",
-							"md:rounded-tr-xl md:rounded-br-xl md:rounded-bl-0",
-							"rounded-bl-xl rounded-br-xl md:rounded-tl-0"
+							"md:rounded-tr-xl md:rounded-br-xl",
+							"rounded-br-xl md:rounded-tl-0",
+							"md:border-l"
 						) }
 					>
 						<div className={ cx("flex flex-col md:items-center") }>
 							{ ["w-3/4", "w-1/2"].map((widthClass, index) => {
-								const heightClass = index === 0
-									? "h-lg"
-									: "h-[20px]";
 								return (
 									<div
 										key={ index }
@@ -184,7 +181,9 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 											"mb-xxxs",
 											"rounded-sm",
 											widthClass,
-											heightClass
+											index === 1
+												? "h-lg"
+												: "h-[20px]"
 										) }
 									/>
 								);
@@ -295,21 +294,17 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 							) } >
 
 								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
-									const bgClass = index === 0
-										? "bg-secondary-alt-300"
-										: "bg-secondary-alt-400";
-
 									return (
 										<div
 											key={ index }
 											className={ cx(
-												"bg-secondary-alt-300",
 												"mb-xxxs",
 												"rounded-sm",
 												"h-md",
-												bgClass,
 												widthClass,
-
+												index === 0
+													? "bg-secondary-alt-400"
+													: "bg-secondary-alt-300"
 											) }
 										/>
 									);
@@ -349,24 +344,20 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						) }>
 
 							{ ["w-3/5", "w-2/5", "w-3/6","w-3/5"].map((widthClass, index) => {
-								const bgClass = index === 3
-									? "bg-secondary-alt-400"
-									: "bg-secondary-alt-300";
-								const heightClass = index === 2
-									? "h-md"
-									: index === 3
-										? "h-sm"
-										: "h-[20px]";
 								return (
-
 									<div
 										key={ index }
 										className={ cx(
 											"rounded-sm",
 											widthClass,
-											heightClass,
-											bgClass
-
+											index === 2
+												? "h-md"
+												: index === 3
+													? "h-sm"
+													: "h-[20px]",
+											index === 3
+												? "bg-secondary-alt-400"
+												: "bg-secondary-alt-300"
 										) }
 									/>
 								);
@@ -381,36 +372,26 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 							"items-end"
 						) }>
 
-							{ ["w-3/6", "w-2/5", "w-3/5"].map((widthClass, index)=> {
-								const bgClass = index === 1
-									? "bg-secondary-alt-300"
-									: "bg-secondary-alt-400";
-								const roundClass = index === 2
-									? "rounded-full"
-									: "rounded-sm";
-								const heightClass = index === 1
-									? "h-[20px]"
-									: "h-md";
-								const marginsClass = index === 0
-									? "mt-xxs"
-									: index === 2
-										? "mt-xxs"
-										: "mt-0";
-								return (
-
-									<div
-										key={ index }
-										className={ cx(
-											roundClass,
-											widthClass,
-											heightClass,
-											bgClass,
-											marginsClass,
-
-										) }
-									/>
-								);
-							}) }
+							{ ["w-3/6", "w-2/5", "w-3/5"].map((widthClass, index) => (
+								<div
+									key={ index }
+									className={ cx(
+										index === 2
+											? "rounded-full"
+											: "rounded-sm",
+										widthClass,
+										index === 1
+											? "h-[20px]"
+											: "h-md",
+										index === 1
+											? "bg-secondary-alt-300"
+											: "bg-secondary-alt-400",
+										index === 0 || index === 2
+											? "mt-xxs"
+											: "mt-0"
+									) }
+								/>
+							)) }
 						</div>
 					</div>
 
@@ -435,7 +416,7 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 					<div className={ cx(
 						"flex",
 						"border-b",
-						"border-secondary-alt-400",
+						"border-secondary-alt-300",
 						"mt-sm",
 						"-mx-sm"
 

--- a/src/components/UiSkeleton/UiSkeleton.tsx
+++ b/src/components/UiSkeleton/UiSkeleton.tsx
@@ -81,32 +81,14 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 								) }
 							/>
 
-							<div className={ cx("flex", "flex-wrap", "gap-xs", "mb-xxs") }>
-								{ ["w-2/5", "w-1/4"].map((widthClass, index) => {
-									return (
-										<div
-											key={ index }
-											className={ cx(widthClass, "h-md", "bg-secondary-alt-300", "rounded-sm") }
-										/>
-									);
-								}) }
+							<div className={ cx("flex flex-wrap gap-xs mb-xxs") }>
+								<div className={ cx("w-2/5 h-md bg-secondary-alt-300 rounded-sm") } />
+								<div className={ cx("w-1/4 h-md bg-secondary-alt-300 rounded-sm") } />
 							</div>
 
-							<div className={ cx("flex", "justify-between") }>
-								{ ["w-1/3", "w-1/4"].map((widthClass, index) => {
-									return (
-										<div
-											key={ index }
-											className={ cx(
-												widthClass,
-												"h-[20px]",
-												"bg-secondary-alt-300",
-												"rounded-sm",
-												"mb-xxs"
-											) }
-										/>
-									);
-								}) }
+							<div className={ cx("flex justify-between") }>
+								<div className={ cx("w-1/3 h-[20px] bg-secondary-alt-300 rounded-sm mb-xxs") } />
+								<div className={ cx("w-1/4 h-[20px] bg-secondary-alt-300 rounded-sm mb-xxs") } />
 							</div>
 						</div>
 
@@ -116,44 +98,13 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 								"md:border-r border-secondary-alt-300",
 								"p-xs md:border-b-0 border-b"
 							) }>
-								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
-									return (
-										<div
-											key={ index }
-											className={ cx(
-												"bg-secondary-alt-300",
-												"mb-xxxs",
-												"rounded-sm",
-												widthClass,
-												index === 1
-													? "h-md"
-													: "h-[20px]"
-											) }
-										/>
-									);
-								}) }
+								<div className={ cx("bg-secondary-alt-300 mb-xxxs rounded-sm w-2/3 h-[20px]") } />
+								<div className={ cx("bg-secondary-alt-300 mb-xxxs rounded-sm w-2/4 h-md") } />
 							</div>
 
-							<div className={ cx(
-								"flex flex-col justify-between md:justify-center md:items-center md:flex-col",
-								"p-xs"
-							) }>
-								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
-									return (
-										<div
-											key={ index }
-											className={ cx(
-												"bg-secondary-alt-300",
-												"mb-xxxs",
-												"rounded-sm",
-												widthClass,
-												index === 1
-													? "h-md"
-													: "h-[20px]"
-											) }
-										/>
-									);
-								}) }
+							<div className={ cx("flex flex-col justify-between md:justify-center md:items-center md:flex-col p-xs") }>
+								<div className={ cx("bg-secondary-alt-300 mb-xxxs rounded-sm h-md w-2/3") } />
+								<div className={ cx("bg-secondary-alt-300 mb-xxxs rounded-sm h-md w-2/4") } />
 							</div>
 						</div>
 					</div>
@@ -171,30 +122,16 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						) }
 					>
 						<div className={ cx("flex flex-col md:items-center w-full") }>
-							{ ["w-3/4", "w-1/2"].map((widthClass, index) => {
-								return (
-									<div
-										key={ index }
-										className={ cx(
-											"bg-secondary-alt-400",
-											"mb-xxxs",
-											"rounded-sm",
-											widthClass,
-											index === 1
-												? "h-lg"
-												: "h-[20px]"
-										) }
-									/>
-								);
-							}) }
+							<div className={ cx("bg-secondary-alt-300", "mb-xxxs", "rounded-sm", "h-lg", "w-[120px]") } />
+							<div className={ cx("bg-secondary-alt-300", "mb-xxxs", "rounded-sm", "h-lg", "w-[120px]") } />
 						</div>
 
 						<div
 							className={ cx(
-								"bg-secondary-alt-500",
+								"bg-secondary-alt-400",
 								"h-xxl",
 								"rounded-sm",
-								"w-3/4 md:w-4/5"
+								"w-full"
 							) }
 						/>
 					</div>
@@ -272,61 +209,26 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 							) }
 						/>
 					</div>
-					<div className={ cx(
-						"grid",
-						"grid-cols-3",
+					<div className={ cx("grid grid-cols-3") }>
+						<div className={ cx("border border-l-0 border-secondary-alt-300 py-xxs place-items-center") }>
+							<div className={ cx("mb-xxxs rounded-sm h-md w-2/3 bg-secondary-alt-400") } />
+							<div className={ cx("mb-xxxs rounded-sm h-md w-2/4 bg-secondary-alt-300") } />
+						</div>
 
-					) } >
-						{ Array.from({
-							length: 3
-						}).map((_, index)=> (
-							<div key={ index } className={ cx(
-								"border",
-								"border-l-0",
-								"border-secondary-alt-300",
-								"py-xxs",
-								"place-items-center",
-								index === 2
-									? "border-r-0"
-									: ""
+						<div className={ cx("border border-l-0 border-secondary-alt-300 py-xxs place-items-center") }>
+							<div className={ cx("mb-xxxs rounded-sm h-md w-2/3 bg-secondary-alt-400") } />
+							<div className={ cx("mb-xxxs rounded-sm h-md w-2/4 bg-secondary-alt-300") } />
+						</div>
 
-							) } >
-
-								{ ["w-2/3", "w-2/4"].map((widthClass, index) => {
-									return (
-										<div
-											key={ index }
-											className={ cx(
-												"mb-xxxs",
-												"rounded-sm",
-												"h-md",
-												widthClass,
-												index === 0
-													? "bg-secondary-alt-400"
-													: "bg-secondary-alt-300"
-											) }
-										/>
-									);
-								}) }
-							</div>
-
-						)) }
-
+						<div className={ cx("border border-l-0 border-secondary-alt-300 py-xxs place-items-center border-r-0") }>
+							<div className={ cx("mb-xxxs rounded-sm h-md w-2/3 bg-secondary-alt-400") } />
+							<div className={ cx("mb-xxxs rounded-sm h-md w-2/4 bg-secondary-alt-300") } />
+						</div>
 					</div>
 
-					<div className={ cx(
-						"flex",
-						"gap-sm",
-						"my-xxs"
-					) }>
-						{ ["w-2/6", "w-2/6"].map((widthClass, index) => {
-							return (
-								<div
-									key={ index }
-									className={ cx(widthClass, "h-md", "bg-secondary-alt-300", "rounded-sm") }
-								/>
-							);
-						}) }
+					<div className={ cx("flex gap-sm my-xxs") }>
+						<div className={ cx("w-2/6 h-md bg-secondary-alt-300 rounded-sm") } />
+						<div className={ cx("w-2/6 h-md bg-secondary-alt-300 rounded-sm") } />
 					</div>
 
 					<div className={ cx(
@@ -334,63 +236,17 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						"justify-between"
 					) }>
 
-						<div className={ cx(
-							"flex",
-							"flex-col",
-							"gap-xxxs",
-							"w-full"
-
-						) }>
-
-							{ ["w-3/5", "w-2/5", "w-3/6","w-3/5"].map((widthClass, index) => {
-								return (
-									<div
-										key={ index }
-										className={ cx(
-											"rounded-sm",
-											widthClass,
-											index === 2
-												? "h-md"
-												: index === 3
-													? "h-sm"
-													: "h-[20px]",
-											index === 3
-												? "bg-secondary-alt-400"
-												: "bg-secondary-alt-300"
-										) }
-									/>
-								);
-							}) }
+						<div className={ cx("flex flex-col gap-xxxs w-full") }>
+							<div className={ cx("rounded-sm w-3/5 h-[20px] bg-secondary-alt-300") } />
+							<div className={ cx("rounded-sm w-2/5 h-[20px] bg-secondary-alt-300") } />
+							<div className={ cx("rounded-sm w-3/6 h-md bg-secondary-alt-300") } />
+							<div className={ cx("rounded-sm w-3/5 h-sm bg-secondary-alt-400") } />
 						</div>
 
-						<div className={ cx(
-							"flex",
-							"flex-col",
-							"gap-xxxs",
-							"w-full",
-							"items-end"
-						) }>
-
-							{ ["w-3/6", "w-2/5", "w-3/5"].map((widthClass, index) => (
-								<div
-									key={ index }
-									className={ cx(
-										index === 2
-											? "rounded-full"
-											: "rounded-sm",
-										widthClass,
-										index === 1
-											? "h-[20px]"
-											: "h-md",
-										index === 1
-											? "bg-secondary-alt-300"
-											: "bg-secondary-alt-400",
-										index === 0 || index === 2
-											? "mt-xxs"
-											: "mt-0"
-									) }
-								/>
-							)) }
+						<div className={ cx("flex flex-col gap-xxxs w-full items-end") }>
+							<div className={ cx("rounded-sm w-3/6 h-md bg-secondary-alt-400 mt-xxs") } />
+							<div className={ cx("rounded-sm w-2/5 h-[20px] bg-secondary-alt-300 mt-0") } />
+							<div className={ cx("rounded-full w-3/5 h-md bg-secondary-alt-400 mt-xxs") } />
 						</div>
 					</div>
 

--- a/src/components/UiSkeleton/UiSkeleton.tsx
+++ b/src/components/UiSkeleton/UiSkeleton.tsx
@@ -25,12 +25,13 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						"border-secondary-alt-300",
 						"md:grid md:grid-cols-[120px_1fr_180px]",
 						"rounded-2xl",
+						"overflow-hidden"
 					) }
 				>
 					<div
 						className={ cx(
 							"ui-skeleton-card__content",
-							"bg-secondary-alt-300",
+							"bg-secondary-alt-200",
 							"flex gap-xs items-center justify-center",
 							"px-sm py-xxs",
 							"md:border-b-0 border-t-0 border-b border-secondary-alt-300",
@@ -72,7 +73,7 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						<div className={ cx("grid", "gap-xxs", "p-sm") }>
 							<div
 								className={ cx(
-									"bg-secondary-alt-400",
+									"bg-secondary-alt-300",
 									"h-md",
 									"mb-xxs",
 									"rounded-sm",
@@ -99,9 +100,7 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 											className={ cx(
 												widthClass,
 												"h-[20px]",
-												index === 0
-													? "bg-secondary-alt-400"
-													: "bg-secondary-alt-300",
+												"bg-secondary-alt-300",
 												"rounded-sm",
 												"mb-xxs"
 											) }
@@ -171,7 +170,7 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 							"md:border-l"
 						) }
 					>
-						<div className={ cx("flex flex-col md:items-center") }>
+						<div className={ cx("flex flex-col md:items-center w-full") }>
 							{ ["w-3/4", "w-1/2"].map((widthClass, index) => {
 								return (
 									<div

--- a/src/components/UiSkeleton/UiSkeleton.tsx
+++ b/src/components/UiSkeleton/UiSkeleton.tsx
@@ -94,14 +94,18 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 
 							<div className={ cx("flex", "justify-between") }>
 								{ ["w-1/3", "w-1/4"].map((widthClass, index) => {
-									const heightClass = "h-[20px]";
-									const bgClass = index === 0
-										? "bg-secondary-alt-400"
-										: "bg-secondary-alt-300";
 									return (
 										<div
 											key={ index }
-											className={ cx(widthClass, heightClass, bgClass, "rounded-sm", "mb-xxs") }
+											className={ cx(
+												widthClass,
+												"h-[20px]",
+												index === 0
+													? "bg-secondary-alt-400"
+													: "bg-secondary-alt-300",
+												"rounded-sm",
+												"mb-xxs"
+											) }
 										/>
 									);
 								}) }
@@ -324,14 +328,10 @@ export const UiSkeleton: React.FC<UiSkeletonProps> = ({
 						"my-xxs"
 					) }>
 						{ ["w-2/6", "w-2/6"].map((widthClass, index) => {
-							const bgClass = index === 0
-								? "bg-secondary-alt-300"
-								: "bg-secondary-alt-300";
-
 							return (
 								<div
 									key={ index }
-									className={ cx(widthClass, "h-md", bgClass, "rounded-sm") }
+									className={ cx(widthClass, "h-md", "bg-secondary-alt-300", "rounded-sm") }
 								/>
 							);
 						}) }

--- a/src/components/UiTabs/UiTabs.tsx
+++ b/src/components/UiTabs/UiTabs.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import cx from "classnames";
 
-type UiTabsProps ={
+type UiTabsProps = {
 	tabs: string[]
 	tabsModel: string,
 	className: string
@@ -20,6 +20,7 @@ export const UiTabs: React.FC<UiTabsProps> = ({
 			"ui-tabs",
 			"grid",
 			"grid-flow-col",
+			"items-stretch",
 			"rounded-full",
 			"bg-secondary-alt-200",
 			"p-[2px]",
@@ -30,6 +31,9 @@ export const UiTabs: React.FC<UiTabsProps> = ({
 				<li
 					key={ tab }
 					className={ cx(
+						"flex",
+						"items-center",
+						"justify-center",
 						"rounded-full",
 						"text-center",
 						tabsModel === tab && "bg-white border border-secondary-alt-600 text-secondary-500",
@@ -37,7 +41,8 @@ export const UiTabs: React.FC<UiTabsProps> = ({
 					) }
 				>
 					<label className={ cx(
-						"block",
+						"flex",
+						"items-center",
 						"cursor-pointer",
 						"px-md",
 						"py-xxs"


### PR DESCRIPTION
1: Adjusts the RESULT_CARD kind in UISkeleton to support mobile styling directly with Tailwind.

In the long term, the goal is to eliminate the RESULT_CARD_MOBILE type. Mobile-specific variants shouldn't be handled through the kind prop.
The kind prop should instead represent different UI loaders (e.g., different card types, loaders, and so on...).

2: UITabs - vertically align labels
Noticible on mobile view with the loans results