### PR TITLE
AA-596 update(pills): update pills in UI

### DIFF
--- a/src/components/UiPills/UiPills.stories.tsx
+++ b/src/components/UiPills/UiPills.stories.tsx
@@ -28,7 +28,25 @@ const meta = {
 				type: "text",
 			},
 			description: "Pills Children",
-		}
+		},
+		fullWidth: {
+			control: {
+				type: "boolean",
+			},
+			description: "Pills Full Width",
+		},
+		justifyCenter: {
+			control: {
+				type: "boolean",
+			},
+			description: "Pills Center Align",
+		},
+		rounded: {
+			control: {
+				type: "boolean",
+			},
+			description: "Pills Rounded",
+		},
 	},
 	args: {
 		kind: EBadgeKind.PRIMARY,
@@ -47,6 +65,9 @@ export const Primary: Story = {
 			kind={ args.kind }
 			size={ args.size }
 			icon={ <UiIcon name={ ["far", "face-smile"] } size={ ESize.XS }/> }
+			fullWidth={ args.fullWidth }
+			rounded={ args.rounded }
+			justifyCenter={ args.justifyCenter }
 		>
 			{ args.children }
 		</UiPills>

--- a/src/components/UiPills/UiPills.stories.tsx
+++ b/src/components/UiPills/UiPills.stories.tsx
@@ -73,3 +73,60 @@ export const Primary: Story = {
 		</UiPills>
 	)
 };
+
+export const Rounded: Story = {
+	args: {
+		rounded: true,
+		children: "Rounded Pill",
+	},
+	render: (args)=>(
+		<UiPills
+			kind={ args.kind }
+			size={ args.size }
+			icon={ <UiIcon name={ ["far", "face-smile"] } size={ ESize.XS }/> }
+			rounded={ args.rounded }
+		>
+			{ args.children }
+		</UiPills>
+	)
+};
+
+export const FullWidth: Story = {
+	args: {
+		fullWidth: true,
+		children: "Full Width Pill",
+	},
+	render: (args)=>(
+		<UiPills
+			kind={ args.kind }
+			size={ args.size }
+			icon={ <UiIcon name={ ["far", "face-smile"] } size={ ESize.XS }/> }
+			fullWidth={ args.fullWidth }
+		>
+			{ args.children }
+		</UiPills>
+	)
+};
+
+export const FullWidthAndCenterAligned: Story = {
+	args: {
+		fullWidth: true,
+		rounded: true,
+		justifyCenter: true,
+		children: "Full Width and Center Aligned",
+		kind: EBadgeKind.ACCENT,
+		size: EBadgeSize.LARGE,
+	},
+	render: (args)=>(
+		<UiPills
+			kind={ args.kind }
+			size={ args.size }
+			icon={ <UiIcon name={ ["far", "face-smile"] } size={ ESize.XS }/> }
+			fullWidth={ args.fullWidth }
+			rounded={ args.rounded }
+			justifyCenter={ args.justifyCenter }
+		>
+			{ args.children }
+		</UiPills>
+	)
+};

--- a/src/components/UiPills/UiPills.tsx
+++ b/src/components/UiPills/UiPills.tsx
@@ -9,6 +9,8 @@ interface IUiPills {
 	size?: EBadgeSize,
 	icon?: React.ReactNode,
 	rounded?: boolean,
+	justifyCenter?: boolean,
+	fullWidth?: boolean,
 	className?: string
 }
 
@@ -33,17 +35,28 @@ export const UiPills: React.FC<IUiPills> = ({
 	kind = EBadgeKind.PRIMARY,
 	size = EBadgeSize.SMALL,
 	className,
+	justifyCenter = false,
 	icon,
-	rounded = false
+	rounded = false,
+	fullWidth
 }) => {
 	return (
 		<div className={ cx(
 			"ui-pills",
-			"grid w-max grid-flow-col justify-start",
+			"grid grid-flow-col",
 			"items-center",
 			"gap-xxxs",
-			"px-xxs py-xxxs",
+			"py-xxxs",
+			rounded
+				? "px-xs"
+				: "px-xxs",
 			"overflow-hidden",
+			fullWidth
+				? "w-full"
+				: "w-max",
+			justifyCenter
+				? "justify-center"
+				: "justify-start",
 			rounded
 				? "rounded-full"
 				: "rounded-sm",
@@ -53,7 +66,7 @@ export const UiPills: React.FC<IUiPills> = ({
 			{ icon }
 			{ children
 				? (
-					<UiTypography size={ sizeEnums[size] } weight={ ETextWeight.SEMI_BOLD } className="whitespace-nowrap">
+					<UiTypography lineHeight size={ sizeEnums[size] } weight={ ETextWeight.SEMI_BOLD } className="whitespace-nowrap">
 						{ children }
 					</UiTypography>
 				)


### PR DESCRIPTION
update pills as we need ability to make them fullWidth and text centered for the broadband Featured Cards availability.

Also needed to add lineHeight, as they have it in the Figma. This is why it looked like there was not enough y-padding in the pill in Ste Mc's Add-On card.

px amount is conditional depending on if 'rounded' is true or not, matching the Figma.